### PR TITLE
Changed loading of widget-3dviewer from jsfiddle to github, for latest changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ not conflict with other ChiliPeppr objects.
 | ID                    | com-chilipeppr-workspace-grbl |
 | Name                  | Workspace / grbl |
 | Description           | A ChiliPeppr Workspace grbl. |
-| chilipeppr.load() URL | http://raw.githubusercontent.com/raykholo/workspace-grbl/master/auto-generated-workspace.html |
-| Edit URL              | http://ide.c9.io/raykholo/workspace-grbl |
-| Github URL            | http://github.com/raykholo/workspace-grbl |
-| Test URL              | https://preview.c9users.io/raykholo/workspace-grbl/workspace.html |
+| chilipeppr.load() URL | http://raw.githubusercontent.com/wd77/workspace-grbl/master/auto-generated-workspace.html |
+| Edit URL              | http://ide.c9.io/wd77/workspace-grbl |
+| Github URL            | http://github.com/wd77/workspace-grbl |
+| Test URL              | https://preview.c9users.io/wd77/workspace-grbl/workspace.html |
 
 ## Example Code for chilipeppr.load() Statement
 
@@ -34,7 +34,7 @@ back the instance of it to init() it.
 // this workspace should be loaded into.
 chilipeppr.load(
   "#pnlWorkspace",
-  "http://raw.githubusercontent.com/raykholo/workspace-grbl/master/auto-generated-workspace.html",
+  "http://raw.githubusercontent.com/wd77/workspace-grbl/master/auto-generated-workspace.html",
   function() {
     // Callback after workspace loaded into #pnlWorkspace
     // Now use require.js to get reference to instantiated workspace
@@ -135,7 +135,7 @@ The table below shows, in order, the methods and properties inside the workspace
           </tr>
       </thead>
       <tbody>
-      <tr valign="top"><td>id</td><td>string</td><td>"com-chilipeppr-workspace-grbl"<br><br>The ID of the widget. You must define this and make it unique.</td></tr><tr valign="top"><td>name</td><td>string</td><td>"Workspace / grbl"</td></tr><tr valign="top"><td>desc</td><td>string</td><td>"A ChiliPeppr Workspace grbl."</td></tr><tr valign="top"><td>url</td><td>string</td><td>"http://raw.githubusercontent.com/raykholo/workspace-grbl/master/auto-generated-workspace.html"</td></tr><tr valign="top"><td>fiddleurl</td><td>string</td><td>"http://ide.c9.io/raykholo/workspace-grbl"</td></tr><tr valign="top"><td>githuburl</td><td>string</td><td>"http://github.com/raykholo/workspace-grbl"</td></tr><tr valign="top"><td>testurl</td><td>string</td><td>"http://workspace-grbl-raykholo.c9users.io/workspace.html"</td></tr><tr valign="top"><td>widgetConsole</td><td>object</td><td>Contains reference to the Console widget object. Hang onto the reference
+      <tr valign="top"><td>id</td><td>string</td><td>"com-chilipeppr-workspace-grbl"<br><br>The ID of the widget. You must define this and make it unique.</td></tr><tr valign="top"><td>name</td><td>string</td><td>"Workspace / grbl"</td></tr><tr valign="top"><td>desc</td><td>string</td><td>"A ChiliPeppr Workspace grbl."</td></tr><tr valign="top"><td>url</td><td>string</td><td>"http://raw.githubusercontent.com/wd77/workspace-grbl/master/auto-generated-workspace.html"</td></tr><tr valign="top"><td>fiddleurl</td><td>string</td><td>"http://ide.c9.io/wd77/workspace-grbl"</td></tr><tr valign="top"><td>githuburl</td><td>string</td><td>"http://github.com/wd77/workspace-grbl"</td></tr><tr valign="top"><td>testurl</td><td>string</td><td>"http://workspace-grbl-wd77.c9users.io/workspace.html"</td></tr><tr valign="top"><td>widgetConsole</td><td>object</td><td>Contains reference to the Console widget object. Hang onto the reference
 so we can resize it when the window resizes because we want it to manually
 resize to fill the height of the browser so it looks clean.</td></tr><tr valign="top"><td>init</td><td>function</td><td>function () <br><br>The workspace's init method. It loads the all the widgets contained in the workspace
 and inits them.</td></tr><tr valign="top"><td>getBillboard</td><td>function</td><td>function () <br><br>Returns the billboard HTML, CSS, and Javascript for this Workspace. The billboard

--- a/auto-generated-workspace.html
+++ b/auto-generated-workspace.html
@@ -206,10 +206,10 @@ cpdefine("inline:com-chilipeppr-workspace-grbl", ["chilipeppr_ready"], function(
         id: "com-chilipeppr-workspace-grbl", // Make the id the same as the cpdefine id
         name: "Workspace / grbl", // The descriptive name of your widget.
         desc: `A ChiliPeppr Workspace grbl.`,
-        url: "http://raw.githubusercontent.com/raykholo/workspace-grbl/master/auto-generated-workspace.html", // The final URL of the working widget as a single HTML file with CSS and Javascript inlined. You can let runme.js auto fill this if you are using Cloud9.
-        fiddleurl: "http://ide.c9.io/raykholo/workspace-grbl", // The edit URL. This can be auto-filled by runme.js in Cloud9 if you'd like, or just define it on your own to help people know where they can edit/fork your widget
-        githuburl: "http://github.com/raykholo/workspace-grbl", // The backing github repo
-        testurl: "http://workspace-grbl-raykholo.c9users.io/workspace.html", // The standalone working widget so can view it working by itself
+        url: "http://raw.githubusercontent.com/wd77/workspace-grbl/master/auto-generated-workspace.html", // The final URL of the working widget as a single HTML file with CSS and Javascript inlined. You can let runme.js auto fill this if you are using Cloud9.
+        fiddleurl: "http://ide.c9.io/wd77/workspace-grbl", // The edit URL. This can be auto-filled by runme.js in Cloud9 if you'd like, or just define it on your own to help people know where they can edit/fork your widget
+        githuburl: "http://github.com/wd77/workspace-grbl", // The backing github repo
+        testurl: "http://workspace-grbl-wd77.c9users.io/workspace.html", // The standalone working widget so can view it working by itself
         /**
          * Contains reference to the Console widget object. Hang onto the reference
          * so we can resize it when the window resizes because we want it to manually
@@ -978,7 +978,8 @@ cpdefine("inline:com-chilipeppr-workspace-grbl", ["chilipeppr_ready"], function(
             // 3D Viewer
             // http://jsfiddle.net/chilipeppr/y3HRF
             chilipeppr.load("#com-chilipeppr-3dviewer",
-                "http://fiddle.jshell.net/chilipeppr/y3HRF/show/light/",
+                //"http://fiddle.jshell.net/chilipeppr/y3HRF/show/light/",
+                "http://raw.githubusercontent.com/chilipeppr/widget-3dviewer/master/auto-generated-widget.html",
 
                 function() {
                     console.log("got callback done loading 3d");

--- a/workspace.js
+++ b/workspace.js
@@ -813,7 +813,8 @@ cpdefine("inline:com-chilipeppr-workspace-grbl", ["chilipeppr_ready"], function(
             // 3D Viewer
             // http://jsfiddle.net/chilipeppr/y3HRF
             chilipeppr.load("#com-chilipeppr-3dviewer",
-                "http://fiddle.jshell.net/chilipeppr/y3HRF/show/light/",
+                //"http://fiddle.jshell.net/chilipeppr/y3HRF/show/light/",
+                "http://raw.githubusercontent.com/chilipeppr/widget-3dviewer/master/auto-generated-widget.html",
 
                 function() {
                     console.log("got callback done loading 3d");


### PR DESCRIPTION
Some changes were added today to the widget-3dviewer to be able to give a failure when WebGL support is not found.
This workspace was loading from jsfiddle, the changes were made in the github repo, so loading from there is the way to go forward?
